### PR TITLE
Modified for Typeit

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,7 @@
       <main class="main-area">
         <div class="heroImage">
           <div class="heroContent">
-            <script src="https://unpkg.com/typeit@8.7.1/dist/index.umd.js"></script>
-            <h2 id="heroContent"></h2>
+            <h2 id="heroHeader"></h2>
             <a href="insert link to sign up"><button class="heroButton">Get started</button></a>
             <a href="insert link to sign in"><button class="heroButton">Sign in</button></a>
           </div><!-- Close the hero content section -->
@@ -70,4 +69,6 @@
 
   </div><!-- Close the page-wrapper -->
 </body>
+<script src="https://unpkg.com/typeit@8.7.1/dist/index.umd.js"></script>
+<script type = "text/javascript" src="script.js"></script>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
-import TypeIt from "typeit";
+// import TypeIt from "typeit";
 
-new TypeIt ("#heroContent", {
-    strings: "Test string"
+new TypeIt ("#heroHeader", {
+    strings: "Test string",
     speed: 75,
     loop: true,
   }).go();


### PR DESCRIPTION
All I did was move the typeit script to the bottom of the HTML file and added in a script to link the Javascript file to your html file.

Because we included the typeit script in the html, you no longer need the import statement in your js script. The speed error was coming from a missing comma. It should be working now!